### PR TITLE
Add network-bind plug

### DIFF
--- a/snapcraft.tpl.yaml
+++ b/snapcraft.tpl.yaml
@@ -39,3 +39,4 @@ apps:
       - network # retrieve packages
       - home    # read sources and write output
       - removable-media # read sources on media
+      - network-bind # serve live HTML in watch mode


### PR DESCRIPTION
`typst watch --format html doc.typ` generates
`error: failed to start TCP server: Operation not permitted (os error 1)`, most likely due to the lack of this plug.

Just found this repo. Previously filed the bug in the wrong place: https://github.com/typst/typst/issues/6962

See https://snapcraft.io/docs/network-bind-interface